### PR TITLE
fix(v2): fix IsReady lock

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -155,10 +155,12 @@ func (c *Client) IsReady() bool {
 	default:
 	}
 
-	ready := c.mux.TryLock()
-	defer c.mux.Unlock()
+	if c.mux.TryLock() {
+		c.mux.Unlock()
+		return true
+	}
 
-	return ready
+	return false
 }
 
 func (c *Client) fatal(err error) {


### PR DESCRIPTION
If client is not ready, it will try to unlock unlocked lock, which panics with "Unlock of unlocked RWMutex".